### PR TITLE
Fixes #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Full front-end AngularJS template for WordPress API.",
   "main": "index.js",
   "dependencies": {
-    "bower": "^1.7.9"
+    "bower": "^1.7.9",
+    "gulp-concat": "^2.6.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,29 +1,42 @@
 var gulp = require('gulp');
 var gulpCopy = require('gulp-copy');
 var merge = require('merge-stream');
+var concat = require('gulp-concat');
 
 
 module.exports = function() {
+  var javascriptDestFolder = './build/js';
 
-    var javascriptDestFolder = './build/js/lib';
+  var angularCopy = gulp.src([
+    './assets/angular/angular.js',
+    './assets/angular-ui-router/release/angular-ui-router.min.js'
+  ])
+  .pipe(concat('lib/external.js'))
+  .pipe(gulp.dest(javascriptDestFolder));
 
-    var angularSourceFolder = ['./assets/angular/angular.js'];
-    var uiRouterSourceFolder = ['./assets/angular-ui-router/release/angular-ui-router.min.js'];
+  var jsCopy = gulp.src([
+    './src/js/frontpress.js',
+    './src/js/frontpress.config.js',
+    './src/js/*.js',
+    './src/js/**/*.module.js',
+    './src/js/**/*.run.js',
+    './src/js/**/*.factory.js',
+    './src/js/**/*.directive.js',
+    './src/js/**/*.js'
+  ])
+  .pipe(concat('app.js'))
+  .pipe(gulp.dest(javascriptDestFolder));
 
-    var angularCopyOptions = {prefix: 2};
-    var imagesCopyOptions = {prefix: 2};
-    var uiRouterCopyOptions = {prefix: 3};
+  var imagesCopy = gulp.src([
+    './src/images/**/*.*'
+  ])
+  .pipe(gulp.dest('./build/images'));
 
-    var angularCopy = gulp.src(angularSourceFolder).pipe(gulpCopy(javascriptDestFolder, uiRouterCopyOptions));
-    var uiRouterCopy = gulp.src(uiRouterSourceFolder).pipe(gulpCopy(javascriptDestFolder, uiRouterCopyOptions));
-    var imagesCopy = gulp.src(['./src/images/**/*.*']).pipe(gulpCopy('./build/images', imagesCopyOptions));
+  var othersCopy = gulp.src([
+    './src/js/**/*.html',
+    './src/js/**/*.css'
+  ])
+  .pipe(gulp.dest('./build/js'));
 
-    var jsPath = gulp.src([
-        './src/js/**/*.js',
-        './src/js/**/*.html',
-        './src/js/**/*.css'
-    ])
-    .pipe(gulp.dest('./build/js'));
-
-    return merge(angularCopy, uiRouterCopy, imagesCopy, jsPath);
+  return merge(angularCopy, imagesCopy, othersCopy, jsCopy);
 };

--- a/tasks/inject.js
+++ b/tasks/inject.js
@@ -5,23 +5,14 @@ module.exports = function() {
 
 	var staticFilesList = [
 		'./build/css/**/*.css',
-        './build/js/lib/angular.js',
-		'./build/js/lib/angular.*.js',
-		'./build/js/lib/**/*.js',
-		'./build/js/frontpress.js',
-		'./build/js/frontpress.config.js',
-		'./build/js/*.js',
-        './build/js/**/*.module.js',
-		'./build/js/**/*.run.js',
-		'./build/js/**/*.factory.js',
-		'./build/js/**/*.directive.js',
-		'./build/js/**/*.js',
+		'./build/js/lib/external.js',
+		'./build/js/app.js',
 		'!gulpfile.js',
 		'!./tasks/*.js',
 	];
 
 	var injectOptions = {
-        ignorePath: 'build/'
+		ignorePath: 'build/'
 	};
 
 	return gulp.src('src/index.html')


### PR DESCRIPTION
1. Gera dois arquivos javascript na pasta `build`:
   - O `external.js`, que contém todas as libs externas (no caso, atualmente, o `angular` e o `angular-ui-router`);
   - O `app.js`, que é utilizado para juntar os arquivos da aplicação em si.
2. Remove as IIFEs dos arquivos da aplicação, pois as mesmas se tornam desnecessárias após os arquivos serem concatenados.

Abs!
