### PR TITLE
Adicionando diretiva para compartilhamento de post

### DIFF
--- a/src/js/components/full-post/templates/full-post.template.html
+++ b/src/js/components/full-post/templates/full-post.template.html
@@ -1,14 +1,16 @@
 <div>
 	<p ng-if='vc.vm.isLoadingFullPost'>carregando...</p>
-	
+
 	<div ng-if='vc.vm.isLoadingFullPost === false'>
 		<h1 ng-bind-html='vc.vm.title | trustAsHtml' ui-sref='post({postSlug:post.slug})'></h1>
-		
+
 		<p ng-bind='vc.vm.date | date :  "dd/MM/y"'></p>
 
 		<img ng-src='{[{vc.vm.featuredImage}]}' style='max-width: 800px;'>
 
 		<div ng-bind-html='vc.vm.content | trustAsHtml '></div>
+
+        <share url="{{ post.slug }}" title="{{ vc.vm.title }}"></share>
 
 		<div>
 			<span><strong>tags:</strong></span>
@@ -18,8 +20,8 @@
 		<div>
 			<span><strong>categories:</strong></span>
 			<span ng-repeat='categoryName in vc.vm.categoryNames' rel='category tag'>{[{categoryName}]} </span>
-		</div>		
-		
+		</div>
+
 	</div>
 
 </div>

--- a/src/js/components/list-posts/templates/list-posts.template.html
+++ b/src/js/components/list-posts/templates/list-posts.template.html
@@ -1,9 +1,10 @@
-<div> 
+<div>
 	<p ng-if='vc.vm.isLoadingPosts'>Carregando posts</p>
 	<div ng-repeat='post in vc.vm.postsList'>
 		<h2><a ng-bind-html='post.title | trustAsHtml' ui-sref='post({postSlug:post.slug})'></a></h2>
 		<p ng-bind='post.date | date :  "dd/MM/y"'></p>
 		<img ng-src='{[{post.featured_image}]}' style='max-width: 250px;'>
 		<p ng-bind-html='post.excerpt | trustAsHtml '></p>
+        <share url="{{ post.slug }}" title="{{ post.title }}"></share>
 	</div>
 </div>

--- a/src/js/components/share/controllers/share.controller.js
+++ b/src/js/components/share/controllers/share.controller.js
@@ -1,0 +1,42 @@
+(function(){
+
+	"use strict";
+
+	angular.module('frontpress.components.share').controller('ShareController', ShareController);
+
+	function ShareController($scope, $element, $attrs){
+		var vc = this;
+        var url;
+
+        vc.share = function(network) {
+            switch(network) {
+                case 'twitter':
+                    url = vc.getTwitterUrl($attrs.url);
+                    break;
+                case 'facebook':
+                    url = vc.getFacebookUrl($attrs.url);
+                    break;
+                case 'google':
+                    url = vc.getGoogleUrl($attrs.url);
+                    break;
+            }
+
+            if (url)
+                window.open(url, network + '-share', 'width=550,height=235');
+
+            return false
+        }
+
+        vc.getFacebookUrl = function(url) {
+            return 'https://www.facebook.com/sharer/sharer.php?u=' + document.URL + url;
+        }
+
+        vc.getTwitterUrl = function(url) {
+            return 'https://twitter.com/intent/tweet?url=' + document.URL + url + '/&amp;text=' + $attrs.title;
+        }
+
+        vc.getGoogleUrl = function(url) {
+            return 'https://plus.google.com/share?url=' + document.URL + url + '/&amp;t=' + $attrs.title;
+        }
+	}
+})();

--- a/src/js/components/share/directives/share.directive.js
+++ b/src/js/components/share/directives/share.directive.js
@@ -1,0 +1,22 @@
+(function(){
+	"use strict";
+
+	angular.module('frontpress.components.share').directive('share', share);
+
+	function share() {
+		var directive = {
+			restrict: 'E',
+			scope: {
+                url: '@url',
+                title: '@title'
+            },
+			templateUrl: '/js/components/share/templates/share.template.html',
+			controller: 'ShareController',
+			controllerAs: 'vc',
+			bindToController: true
+		};
+
+		return directive;
+	}
+
+})();

--- a/src/js/components/share/share.module.js
+++ b/src/js/components/share/share.module.js
@@ -1,0 +1,5 @@
+(function(){
+	"use strict";
+
+	angular.module('frontpress.components.share', ['frontpress.filters']);
+})();

--- a/src/js/components/share/templates/share.template.html
+++ b/src/js/components/share/templates/share.template.html
@@ -1,0 +1,6 @@
+<div>
+    Share:
+    <a href="#" ng-click="vc.share('twitter')">Twitter</a>
+    <a href="#" ng-click="vc.share('facebook')">Facebook</a>
+    <a href="#" ng-click="vc.share('google')">Google+</a>
+</div>

--- a/src/js/views/post/post.module.js
+++ b/src/js/views/post/post.module.js
@@ -1,5 +1,5 @@
 (function(){
 	"use strict";
 
-	angular.module('frontpress.views.post', ['frontpress.components.full-post', 'ui.router', 'frontpress.components.page-head', 'ngDisqus']);
+	angular.module('frontpress.views.post', ['frontpress.components.full-post', 'frontpress.components.share', 'ui.router', 'frontpress.components.page-head', 'ngDisqus']);
 })();


### PR DESCRIPTION
@teles este PR pretende fechar a issue #24, adicionando uma diretiva para compartilhamento de post.
Quando você for testar, talvez ocorra problema ao clicar no Facebook e no Google+, mas isso ocorre por conta da url ser `localhost`.

Obs.: algumas alterações foram feitas pelo editor, removendo os espaços em branco. 👍 

Vlw!
