### PR TITLE
Minifcando os de javascript em um único arquivo ao utilizar o parâmetro --production

### DIFF
--- a/tasks/inject.js
+++ b/tasks/inject.js
@@ -1,20 +1,27 @@
 var gulp = require('gulp');
 var inject = require('gulp-inject');
+var argv = process.argv;
 
 module.exports = function() {
 	var staticFilesList = [
 		'./build/css/**/*.css',
-		'./build/js/lib/external.js',
-		'./build/js/app.js',
 		'!gulpfile.js',
 		'!./tasks/*.js',
 	];
+
+    if (argv.indexOf('--production') !== -1) {
+        staticFilesList.push('./build/js/main.js')
+    } else {
+        staticFilesList.push('./build/js/dev/external.js', './build/js/dev/main.js');
+    }
 
 	var injectOptions = {
 		ignorePath: 'build/'
 	};
 
+    var injectFiles = gulp.src(staticFilesList, {read: true});
+
 	return gulp.src('src/index.html')
-		.pipe(inject(gulp.src(staticFilesList, {read: true}), injectOptions))
+		.pipe(inject(injectFiles, injectOptions))
 		.pipe(gulp.dest('./build'));
 };


### PR DESCRIPTION
@teles Como combinamos na #32.

Temos uma melhoria para ser feita aqui. Ao salvar o arquivo com o `minify` aplicado, seria interessante apagar os arquivos de `dev`. De forma simples, não tive uma ideia interessante para utilizar neste caso (visto que a task está sendo chamada de forma assíncrona.

Alguma ideia a respeito?
Valeu!
